### PR TITLE
Refactor Http2Connection to use PipeReader for input

### DIFF
--- a/src/CHttpServer/CHttpServer/Http2ResponseWriter.cs
+++ b/src/CHttpServer/CHttpServer/Http2ResponseWriter.cs
@@ -32,7 +32,7 @@ internal class Http2ResponseWriter : IResponseWriter
         _priorityChannel = Channel.CreateUnbounded<StreamWriteRequest>(new UnboundedChannelOptions() { SingleReader = true, AllowSynchronousContinuations = false });
     }
 
-    public async ValueTask RunAsync(CancellationToken token)
+    public async Task RunAsync(CancellationToken token)
     {
         _buffer = ArrayPool<byte>.Shared.Rent(_maxFrameSize);
         try
@@ -72,6 +72,10 @@ internal class Http2ResponseWriter : IResponseWriter
             }
         }
         catch (OperationCanceledException)
+        {
+            // Channel is closed by the connection.
+        }
+        catch (ChannelClosedException)
         {
             // Channel is closed by the connection.
         }

--- a/src/CHttpServer/CHttpServer/PriorityResponseWriter.cs
+++ b/src/CHttpServer/CHttpServer/PriorityResponseWriter.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Channels;
 using CHttpServer.System.Net.Http.HPack;
 using Microsoft.Extensions.ObjectPool;
 
@@ -130,6 +131,10 @@ internal class PriorityResponseWriter : IResponseWriter
                 await WriteAllLevels(token);
         }
         catch (OperationCanceledException)
+        {
+            // Channel is closed by the connection.
+        }
+        catch (ChannelClosedException)
         {
             // Channel is closed by the connection.
         }


### PR DESCRIPTION
This commit refactors the `Http2Connection` class to replace the use of `Stream` with `PipeReader` for reading input data, enhancing efficiency in data handling. Several methods have been updated to accept `ReadOnlySequence<byte>` parameters, improving the processing of incoming data frames.

The `ReadFrameHeader` method now reads from the `PipeReader`, and the `CloseConnection` method completes the `PipeReader` instead of closing a `Stream`. Additional error handling has been added for better management of cancellation and completion scenarios.

The `Http2ResponseWriter` and `PriorityResponseWriter` classes have been updated to handle channel closure exceptions, increasing robustness in asynchronous operations. New utility methods, such as `ToSpan`, have been introduced to streamline data manipulation.

Overall, these changes aim to improve performance, maintainability, and error handling in the HTTP/2 connection implementation.